### PR TITLE
Update storage_account.tf

### DIFF
--- a/storage_account.tf
+++ b/storage_account.tf
@@ -16,8 +16,7 @@ resource "azurerm_storage_account" "aml_sa" {
 # Virtual Network & Firewall configuration
 
 resource "azurerm_storage_account_network_rules" "firewall_rules" {
-  resource_group_name  = azurerm_resource_group.aml_rg.name
-  storage_account_name = azurerm_storage_account.aml_sa.name
+  storage_account_id = azurerm_storage_account.aml_sa.id
 
   default_action             = "Deny"
   ip_rules                   = []


### PR DESCRIPTION
storage_account_name is no longer a supported field. switched to storage_accoun_id

resource_group_name does not exist anymore within azurerm_storage_account_network_rules

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account